### PR TITLE
resolves [BUG] No Images on AT&T Corporate Network #9

### DIFF
--- a/views/copper.py
+++ b/views/copper.py
@@ -12,7 +12,7 @@ copper = fs.AddPagesy(route_prefix="/copper")
 def copper_color_code_page(data: fs.Datasy):
     """RJ45 Scheme Page"""
     view = data.view
-    image = ft.Image(src="../assets/images/25-pair-color-code.png")
+    image = ft.Image(src="/images/25-pair-color-code.png")
     container = ft.Container(
         bgcolor=AppColors.BG,
         # border_radius=35,

--- a/views/fiber_color_code.py
+++ b/views/fiber_color_code.py
@@ -12,7 +12,7 @@ def fiber_color_code_page(data: fs.Datasy):
     """RJ45 Scheme Page"""
     view = data.view
     image = ft.Image(
-        src="../assets/images/fiber_color-code.jpg",
+        src="/images/fiber_color-code.jpg",
         fit=ft.ImageFit.FIT_WIDTH,
     )
     container = ft.Container(

--- a/views/rj45_scheme.py
+++ b/views/rj45_scheme.py
@@ -11,7 +11,7 @@ rj45_scheme = fs.AddPagesy()
 def rj45_scheme_page(data: fs.Datasy):
     """RJ45 Scheme Page"""
     view = data.view
-    image = ft.Image(src="../assets/images/rj45-wiring-schemes.png")
+    image = ft.Image(src="/images/rj45-wiring-schemes.png")
     container = ft.Container(
         bgcolor=AppColors.BG,
         # border_radius=35,


### PR DESCRIPTION
resolves #9

## Summary by Sourcery

Bug Fixes:
- Replace relative image paths with absolute `/images/...` URLs in copper, fiber, and RJ45 scheme views to restore image display.