### PR TITLE
updated upload key

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ team = "2T42Z3DM34"
 # FLET_ANDROID_SIGNING_KEY_STORE_PASSWORD
 # and FLET_ANDROID_SIGNING_KEY_PASSWORD environment variables.
 key_store = "/tmp/UVT.jks" # --android-signing-key-store
-key_alias = "uvt" # --android-signing-key-alias
+key_alias = "upload" # --android-signing-key-alias
 
 [tool.flet.android.permission]
 "android.permission.INTERNET" = true


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Change Android signing key_alias in pyproject.toml from "uvt" to "upload"