### PR TITLE
Update copyright year to 2026 in appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,7 +49,7 @@ for:
 #     - image: Visual Studio 2019
     
 #   build_script:
-#   - flet build windows --project "jkuvt" --product "UVT" --build-version "1.0.0" --copyright "Copyright (c) 2025 KumpeApps LLC" --org net.justinkumpe.apps --company "KumpeApps LLC"
+#   - flet build windows --project "jkuvt" --product "UVT" --build-version "1.0.0" --copyright "Copyright (c) 2026 KumpeApps LLC" --org net.justinkumpe.apps --company "KumpeApps LLC"
 #   after_build:
 #   - 7z a jkuvt-windows.zip %CD%\build\windows\*.exe
 
@@ -90,7 +90,7 @@ for:
 
   build_script:
   - echo "is_mobile=0" >> .env
-  - flet build macos --project "jkuvt" --product "UVT" --build-version "${APPVEYOR_REPO_TAG_NAME:-"11.0.3"}" --build-number $APPVEYOR_BUILD_NUMBER --copyright "Copyright (c) 2025 KumpeApps LLC" --org net.justinkumpe.apps --company "KumpeApps LLC"
+  - flet build macos --project "jkuvt" --product "UVT" --build-version "${APPVEYOR_REPO_TAG_NAME:-"11.0.3"}" --build-number $APPVEYOR_BUILD_NUMBER --copyright "Copyright (c) 2026 KumpeApps LLC" --org net.justinkumpe.apps --company "KumpeApps LLC"
 
   after_build:
   - tar -czvf jkuvt-macos.tar.gz -C build/macos "UVT.app"
@@ -133,7 +133,7 @@ for:
 
   build_script:
   - echo "is_mobile=1" >> .env
-  - flet build ipa --project "jkuvt" --product "UVT" --build-version "${APPVEYOR_REPO_TAG_NAME:-"11.0.3"}" --build-number $APPVEYOR_BUILD_NUMBER --copyright "Copyright (c) 2025 KumpeApps LLC" --org net.justinkumpe.apps --company "KumpeApps LLC"
+  - flet build ipa --project "jkuvt" --product "UVT" --build-version "${APPVEYOR_REPO_TAG_NAME:-"11.0.3"}" --build-number $APPVEYOR_BUILD_NUMBER --copyright "Copyright (c) 2026 KumpeApps LLC" --org net.justinkumpe.apps --company "KumpeApps LLC"
   # --team 2T42Z3DM34
 
   after_build:
@@ -160,7 +160,7 @@ for:
   build_script:
   - echo "is_mobile=1" >> .env
   - curl https://$MATCH_DEPLOY_KEY@raw.githubusercontent.com/kumpeapps/android_certs/main/UVT.jks -o /tmp/UVT.jks
-  - flet build apk --project "uvt" --product "UVT" --build-version "${APPVEYOR_REPO_TAG_NAME:-"11.0.3"}" --build-number $APPVEYOR_BUILD_NUMBER --copyright "Copyright (c) 2025 KumpeApps LLC" --org net.justinkumpe.apps --company "KumpeApps LLC"
+  - flet build apk --project "uvt" --product "UVT" --build-version "${APPVEYOR_REPO_TAG_NAME:-"11.0.3"}" --build-number $APPVEYOR_BUILD_NUMBER --copyright "Copyright (c) 2026 KumpeApps LLC" --org net.justinkumpe.apps --company "KumpeApps LLC"
 
   after_build:
   - tar -czvf jkuvt-apk.tar.gz -C build apk
@@ -184,7 +184,7 @@ for:
   build_script:
   - echo "is_mobile=1" >> .env
   - curl https://$MATCH_DEPLOY_KEY@raw.githubusercontent.com/kumpeapps/android_certs/main/UVT.jks -o /tmp/UVT.jks
-  - flet build aab --project "uvt" --product "UVT" --build-version "${APPVEYOR_REPO_TAG_NAME:-"11.0.3"}" --build-number $APPVEYOR_BUILD_NUMBER --copyright "Copyright (c) 2025 KumpeApps LLC" --org net.justinkumpe.apps --company "KumpeApps LLC"
+  - flet build aab --project "uvt" --product "UVT" --build-version "${APPVEYOR_REPO_TAG_NAME:-"11.0.3"}" --build-number $APPVEYOR_BUILD_NUMBER --copyright "Copyright (c) 2026 KumpeApps LLC" --org net.justinkumpe.apps --company "KumpeApps LLC"
 
   after_build:
   - tar -czvf jkuvt-aab.tar.gz -C build aab
@@ -206,7 +206,7 @@ for:
     - MATCH_DEPLOY_KEY: $MATCH_DEPLOY_KEY
 
   build_script:
-  - flet build web --project "uvt" --product "UVT" --build-version "${APPVEYOR_REPO_TAG_NAME:-"11.0.3"}" --build-number $APPVEYOR_BUILD_NUMBER --copyright "Copyright (c) 2025 KumpeApps LLC" --org net.justinkumpe.apps --company "KumpeApps LLC"
+  - flet build web --project "uvt" --product "UVT" --build-version "${APPVEYOR_REPO_TAG_NAME:-"11.0.3"}" --build-number $APPVEYOR_BUILD_NUMBER --copyright "Copyright (c) 2026 KumpeApps LLC" --org net.justinkumpe.apps --company "KumpeApps LLC"
 
   after_build:
   - tar -czvf jkuvt-web.tar.gz -C build web


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update AppVeyor build scripts for macOS, iOS, Android, and web (plus commented Windows block) to reference the 2026 copyright year in Flet build commands.